### PR TITLE
Use latest git-resource to bypass certificate issue

### DIFF
--- a/ephemeral-diego-smb.yml
+++ b/ephemeral-diego-smb.yml
@@ -127,6 +127,12 @@ resource_types:
   source:
     repository: cftoolsmiths/toolsmiths-envs-resource
 
+- name: git
+  type: docker-image
+  source:
+    repository: concourse/git-resource
+    tag: ubuntu
+
 jobs:
 - name: smb-volume-release-job-tests
   plan:

--- a/ephemeral-diego.yml
+++ b/ephemeral-diego.yml
@@ -162,6 +162,12 @@ resources:
     uri: https://github.com/cloudfoundry-incubator/disaster-recovery-acceptance-tests.git
 
 resource_types:
+- name: git
+  type: docker-image
+  source:
+    repository: concourse/git-resource
+    tag: ubuntu
+
 - name: pcf-pool
 
   type: docker-image

--- a/lts-toolsmiths.yml
+++ b/lts-toolsmiths.yml
@@ -129,6 +129,12 @@ resources:
         - Kilnfile
 
 resource_types:
+- name: git
+  type: docker-image
+  source:
+    repository: concourse/git-resource
+    tag: ubuntu
+
 - name: pcf-pool
 
   type: docker-image


### PR DESCRIPTION
Getting packages from gopkg.in was throwing certificate issues.
This was caused by a combination of:
- Letsencrypt changing its root certificate authority
- git resource-type being pinned to a specific image by default

Old image for git resource doesn't include the new authority.
The problem can easily be solved by redefining the git resource
type to use latest official image.

In a future Concourse vers. this change shouldn't be necessary.