### PR TITLE
Use Dependabot for bumping submodules

### DIFF
--- a/nfs-broker.yml
+++ b/nfs-broker.yml
@@ -12,24 +12,11 @@ resources:
     uri: git@github.com:cloudfoundry/nfsbroker.git
     private_key: ((github.ssh_key))
 
-- name: nfs-volume-release
-  type: git
-  source:
-    branch: master
-    private_key: ((github.ssh_key))
-    uri: git@github.com:cloudfoundry/nfs-volume-release.git
-
 - name: credhub
   type: git
   source:
     branch: main
     uri: https://github.com/cloudfoundry-incubator/credhub
-
-- name: mapfs-release
-  type: git
-  source:
-    branch: master
-    uri: https://github.com/cloudfoundry/mapfs-release.git
 
 jobs:
 - name: security-scan
@@ -55,38 +42,3 @@ jobs:
   - task: build
     file: nfsbroker/scripts/ci/run_unit_and_integration.build.yml
 
-- name: release-job-tests
-  plan:
-  - in_parallel:
-      fail_fast: true
-      steps:
-      - get: persi-ci
-      - get: mapfs-release
-      - get: nfs-volume-release
-      - get: nfsbroker
-        passed:
-        - unit-and-integration-test
-        - security-scan
-        trigger: true
-  - task: bump-submodule
-    file: persi-ci/scripts/ci/bump_submodule.build.yml
-    input_mapping:
-      release-repo: nfs-volume-release
-      submodule-repo: nfsbroker
-    params:
-      SUBMODULE_PATH: src/code.cloudfoundry.org/nfsbroker
-  - task: rspec
-    file: persi-ci/scripts/ci/run-rspec.build.yml
-    input_mapping:
-      test-repo: bumped-repo
-  - task: bosh-release-test
-    attempts: 3
-    input_mapping:
-      nfs-volume-release: bumped-repo
-      nfs-volume-release-concourse-tasks: bumped-repo
-    file: nfs-volume-release/scripts/ci/run_bosh_release_tests.build.yml
-    privileged: true
-  - put: nfs-volume-release
-    params:
-      repository: bumped-repo
-      rebase: true


### PR DESCRIPTION
Use dependabot and a PR flow instead bumping submodules manually.
Let Dependabot open a PR. Then test. If tests pass then merge PR.
We will encode these tests in nfs-volume-release pipeline instead of here.