### PR TITLE
Enable PR flow for smb-volume-release repo

### DIFF
--- a/ephemeral-diego-smb.yml
+++ b/ephemeral-diego-smb.yml
@@ -171,10 +171,10 @@ jobs:
       fail_fast: true
       steps:
       - get: smb-volume-release
+        trigger: true
         passed:
         - smb-volume-release-job-tests
       - get: every-hour
-        trigger: true
 
 - name: claim-env
   plan:

--- a/ephemeral-diego-smb.yml
+++ b/ephemeral-diego-smb.yml
@@ -394,31 +394,14 @@ jobs:
       action: unclaim
       env_file: smith-env/metadata
 
-- name: merge-pr-tests
-  plan:
-  - in_parallel:
-      fail_fast: true
-      steps:
-      - get: smb-volume-release
-        passed:
-        - pats
-        - drats
-        - cats
-        trigger: true
-  - task: bosh-release-test
-    attempts: 3
-    input_mapping:
-      smb-volume-release: smb-volume-release
-      smb-volume-release-concourse-tasks: smb-volume-release
-    file: smb-volume-release/scripts/ci/run_bosh_release_tests.build.yml
-    privileged: true
-
 - name: merge-pr
   plan:
   - get: smb-volume-release
     trigger: true
     passed:
-    - merge-pr-tests
+    - pats
+    - drats
+    - cats
   - put: smb-volume-release
     params:
       merge: true

--- a/ephemeral-diego-smb.yml
+++ b/ephemeral-diego-smb.yml
@@ -54,6 +54,14 @@ resources:
     branch: freezing
 
 - name: smb-volume-release
+  type: pull-request
+  source:
+    base_branch: master
+    access_token: ((github.access_token))
+    repository: cloudfoundry/smb-volume-release
+    disable_forks: true
+
+- name: smb-volume-release-master
   type: git
   source:
     branch: master
@@ -132,6 +140,11 @@ resource_types:
   source:
     repository: concourse/git-resource
     tag: ubuntu
+
+- name: pull-request
+  type: docker-image
+  source:
+    repository: cryogenics/pr-queue-resource
 
 jobs:
 - name: smb-volume-release-job-tests
@@ -391,9 +404,7 @@ jobs:
         steps:
           - get: persi-ci
           - get: release
-            resource: smb-volume-release
-            passed:
-              - pats
+            resource: smb-volume-release-master
           - get: version
             resource: smb-volume-version
             params:
@@ -414,7 +425,7 @@ jobs:
       file: persi-ci/scripts/ci/generate_github_release.build.yml
       params:
         BASE_RELEASE_NAME: smb-volume
-    - put: smb-volume-release
+    - put: smb-volume-release-master
       params:
         repository: finalized-release/release
         tag: version/number
@@ -437,13 +448,13 @@ jobs:
             repository: johnajimenez/ubuntu-bash-jq-curl-git
             tag: latest
         inputs:
-          - name: smb-volume-release
+          - name: smb-volume-release-master
         run:
           path: bash
           args:
             - -exc
             - |
-              cd smb-volume-release
+              cd smb-volume-release-master
               export LATEST_GIT_SHA=$(curl -H "X-TrackerToken: ((tracker-api-token))" "https://www.pivotaltracker.com/services/v5/projects/1518687/cicd/54a073c28e26614473035e9d13ba9866" | jq -r '.latest_git_sha')
               git config --global core.pager cat
               if git log $LATEST_GIT_SHA~..$LATEST_GIT_SHA; then

--- a/ephemeral-diego-smb.yml
+++ b/ephemeral-diego-smb.yml
@@ -394,6 +394,33 @@ jobs:
       action: unclaim
       env_file: smith-env/metadata
 
+- name: merge-pr-tests
+  plan:
+  - in_parallel:
+      fail_fast: true
+      steps:
+      - get: smb-volume-release
+        passed:
+        - pats
+        trigger: true
+  - task: bosh-release-test
+    attempts: 3
+    input_mapping:
+      smb-volume-release: smb-volume-release
+      smb-volume-release-concourse-tasks: smb-volume-release
+    file: smb-volume-release/scripts/ci/run_bosh_release_tests.build.yml
+    privileged: true
+
+- name: merge-pr
+  plan:
+  - get: smb-volume-release
+    trigger: true
+    passed:
+    - merge-pr-tests
+  - put: smb-volume-release
+    params:
+      merge: true
+      repository: smb-volume-release
 
 - name: shipit-smb
   serial_groups:

--- a/ephemeral-diego-smb.yml
+++ b/ephemeral-diego-smb.yml
@@ -402,6 +402,8 @@ jobs:
       - get: smb-volume-release
         passed:
         - pats
+        - drats
+        - cats
         trigger: true
   - task: bosh-release-test
     attempts: 3


### PR DESCRIPTION
Now that dependabot has been enabled in this repo, the missing piece was to automatically test dependabot PRs and merge them when successful.

This PullRequest implements exactly that.
One tradeoff is that we had to disable running the pipeline every hour as it conflicted with the way cryogenics/pr-queue-resource works.
We are still trying to figure out how to get the best of both worlds: pr-flow + exercising the pipeline frequently.