### PR TITLE
Use Dependabot for bumping submodules [mapfs]

### DIFF
--- a/mapfs.yml
+++ b/mapfs.yml
@@ -10,13 +10,6 @@ resources:
   source:
     uri: https://github.com/zfsonlinux/fstest.git
 
-- name: mapfs-release
-  type: git
-  source:
-    branch: master
-    private_key: ((github.ssh_key))
-    uri: git@github.com:cloudfoundry/mapfs-release.git
-
 - name: persi-ci
   type: git
   source:
@@ -55,28 +48,3 @@ jobs:
         PATHS: "./"
       input_mapping:
         release-dir: mapfs
-
-- name: bump-submodule
-  plan:
-  - in_parallel:
-      fail_fast: true
-      steps:
-      - get: persi-ci
-      - get: mapfs-release
-      - get: mapfs
-        passed:
-        - unit-test
-        - fs-test
-        - security-scan
-        trigger: true
-  - task: bump-submodule
-    file: persi-ci/scripts/ci/bump_submodule.build.yml
-    input_mapping:
-      release-repo: mapfs-release
-      submodule-repo: mapfs
-    params:
-      SUBMODULE_PATH: src/mapfs
-  - put: mapfs-release
-    params:
-      repository: bumped-repo
-      rebase: true


### PR DESCRIPTION
Use dependabot and a PR flow instead bumping submodules manually.
Let Dependabot open a PR. Then test. If tests pass then merge PR.
We will encode these tests in mapfs-release pipeline instead of here.