### PR TITLE
Fix dependency requiring golang 1.16+

### DIFF
--- a/scripts/ci/security-scan
+++ b/scripts/ci/security-scan
@@ -10,7 +10,7 @@ pushd release-dir
         export PATH=$PWD/bin:$PATH
     fi
 
-    go get github.com/securego/gosec/cmd/gosec
+    GO111MODULE=on go get github.com/securego/gosec/v2/cmd/gosec@v2.9.1
 
     IFS=':' read -r -a array <<< "$PATHS"
 


### PR DESCRIPTION
Latest changes in gosec don't work with go <1.16:
https://github.com/securego/gosec/pull/725

We need more careful testing before doing such version bump
Pinning version of gosec until we can perform such testing