### PR TITLE
Add rule for smoke-tests release

### DIFF
--- a/operations/pas/remove-paths-from-releases.yml
+++ b/operations/pas/remove-paths-from-releases.yml
@@ -23,6 +23,8 @@
 - type: remove
   path: /releases/name=cf-smoke-tests?/url?
 - type: remove
+  path: /releases/name=smoke-tests?/url?
+- type: remove
   path: /releases/name=cf-syslog-drain?/url?
 - type: remove
   path: /releases/name=cflinuxfs3?/url?


### PR DESCRIPTION
Newer TAS versions renamed the release
from cf-smoke-tests to smoke-tests.

Since we also tests agains Opsmanger 2.7
we can't just modify the existing rule.