### PR TITLE
Fix go get unsupported outside module in latest go

### DIFF
--- a/dockerfiles/bosh-release-tests/Dockerfile
+++ b/dockerfiles/bosh-release-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.16
 
 RUN wget https://github.com/cloudfoundry/bosh-cli/releases/download/v5.5.1/bosh-cli-5.5.1-linux-amd64
 RUN chmod +x bosh-cli-5.5.1-linux-amd64


### PR DESCRIPTION
In latest versions of go `go get` is no longer supported outside a module.
Trying to use `go install` instead raises another issue with gomega:
`package github.com/onsi/gomega is not a main package`

I'm going to pin this image to use go 1.16 to minimise the risk of breaking
other pipelines.