### PR TITLE
Fix tas resource to point to a valid path

### DIFF
--- a/lts-toolsmiths.yml
+++ b/lts-toolsmiths.yml
@@ -133,7 +133,7 @@ resources:
       username: ((github.https_username))
       password: ((github.access_token))
       paths:
-        - Kilnfile
+        - tas/Kilnfile
 
 resource_types:
 - name: git


### PR DESCRIPTION
[#181957120]

When replacing p-runtime with new tas repo we should have
replaced also the `path` condition since the Kilnfile is place
in a different location in the new pivotal/tas repository

Related: #27 

Signed-off-by: Fernando Naranjo <fnaranjo@vmware.com>