### PR TITLE
NFS 2.3 branch reached EOGS

### DIFF
--- a/sync-pipelines.sh
+++ b/sync-pipelines.sh
@@ -45,13 +45,5 @@ jobs:
       mapfs-tag: v1.2.0
       nfs-semver-initial-version: 5.0.3
       pas-version: us_2_10
-  - set_pipeline: lts-toolsmiths-2.3
-    file: persi-ci/lts-toolsmiths.yml
-    vars:
-      lts-nfs-branch: v2.3
-      mapfs-tag: v1.2.0
-      nfs-semver-initial-version: 2.3.3
-      pas-version: us_2_7
-
 EOF
 )


### PR DESCRIPTION
TAS 2.7 (the TAS release family which uses nfs-volume-release 2.3) reached End of General Support in April 30th, 2022.

[#182210532]

We don't need to keep dependencies up-to-date, since TAS 2.7 is no longer officially supported.