### PR TITLE
Changed mapfs pipeline bosh-deploy-cf to use the essentials-cf6 image…

### DIFF
--- a/scripts/ci/deploy-cf-with-multiple-releases.build.yml
+++ b/scripts/ci/deploy-cf-with-multiple-releases.build.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: relintdockerhubpushbot/cf-deployment-concourse-tasks
+    repository: cryogenics/essentials-cf6
     tag: latest
 
 inputs:


### PR DESCRIPTION
…. We have seen this fail due to it using an old version of the bosh-cli