### PR TITLE
switch aws cred usage to sts creds with role

### DIFF
--- a/lts-nfs-volume-release-v5.0.yml
+++ b/lts-nfs-volume-release-v5.0.yml
@@ -118,12 +118,13 @@ resources:
 - name: nfsvolume-version
   type: semver
   source:
-    access_key_id: ((aws/lts-nfsvolume-uploader.id))
+    access_key_id: ((aws/lts-nfsvolume-uploader.role_id))
+    assume_role_arn: ((aws/lts-nfsvolume-uploader.role_arn))
     bucket: lts-nfsvolume-release-versions
     initial_version: {{nfs-semver-initial-version}}
     key: {{lts-nfs-branch}}
     region_name: us-west-2
-    secret_access_key: ((aws/lts-nfsvolume-uploader.secret))
+    secret_access_key: ((aws/lts-nfsvolume-uploader.role_secret))
 
 - name: cf-deployment
   type: git
@@ -237,8 +238,9 @@ jobs:
       VENDOR_UPDATES_BRANCH: &golang-vendor-branch bump-golang-vendor-((.:golang-release-version))-into-v5
       COMMIT_USERNAME: bump-golang CI job
       COMMIT_USEREMAIL: mapbu-cryogenics@groups.vmware.com
-      AWS_ACCESS_KEY_ID: ((aws/nfsvolume-uploader.id))
-      AWS_SECRET_ACCESS_KEY: ((aws/nfsvolume-uploader.secret))
+      AWS_ACCESS_KEY_ID: ((aws/nfsvolume-uploader.role_id))
+      AWS_SECRET_ACCESS_KEY: ((aws/nfsvolume-uploader.role_secret))
+      AWS_ROLE_ARN: ((aws/nfsvolume-uploader.role_arn))
   - put: nfs-volume-release-bump-golang
     params:
       repository: release-with-updated-vendored-package
@@ -664,8 +666,9 @@ jobs:
       updated-release-repo: nfs-final-release
       updated-release-tarball: nfs-final-release-tarball
     params:
-      AWS_ACCESS_KEY_ID: ((aws/lts-nfsvolume-uploader.id))
-      AWS_SECRET_ACCESS_KEY: ((aws/lts-nfsvolume-uploader.secret))
+      AWS_ACCESS_KEY_ID: ((aws/lts-nfsvolume-uploader.role_id))
+      AWS_SECRET_ACCESS_KEY: ((aws/lts-nfsvolume-uploader.role_secret))
+      AWS_ROLE_ARN: ((aws/lts-nfsvolume-uploader.role_arn))
       GIT_USERNAME: ((github.user))
       GIT_EMAIL: ((github.email))
       FINAL: true

--- a/mapfs-release.yml
+++ b/mapfs-release.yml
@@ -120,12 +120,13 @@ resources:
 - name: mapfs-version
   type: semver
   source:
-    access_key_id: ((aws/mapfs-uploader.id))
+    access_key_id: ((aws/mapfs-uploader.role_id))
     bucket: mapfs-versions
     initial_version: 1.2.4
     key: current-version
     region_name: us-east-1
-    secret_access_key: ((aws/mapfs-uploader.secret))
+    secret_access_key: ((aws/mapfs-uploader.role_secret))
+    assume_role_arn: ((aws/mapfs-uploader.role_arn))
 
 - name: github-release-mapfs
   type: github-release
@@ -252,8 +253,9 @@ jobs:
       VENDOR_UPDATES_BRANCH: &golang-vendor-branch bump-golang-vendor-((.:golang-release-version))
       COMMIT_USERNAME: bump-golang CI job
       COMMIT_USEREMAIL: mapbu-cryogenics@groups.vmware.com
-      AWS_ACCESS_KEY_ID: ((aws/mapfs-uploader.id))
-      AWS_SECRET_ACCESS_KEY: ((aws/mapfs-uploader.secret))
+      AWS_ACCESS_KEY_ID: ((aws/mapfs-uploader.role_id))
+      AWS_SECRET_ACCESS_KEY: ((aws/mapfs-uploader.role_secret))
+      AWS_ROLE_ARN: ((aws/mapfs-uploader.role_arn))
   - put: mapfs-release-bump-golang
     params:
       repository: release-with-updated-vendored-package
@@ -864,8 +866,9 @@ jobs:
       updated-release-repo: mapfs-final-release
       updated-release-tarball: mapfs-final-release-tarball
     params:
-      AWS_ACCESS_KEY_ID: ((aws/mapfs-uploader.id))
-      AWS_SECRET_ACCESS_KEY: ((aws/mapfs-uploader.secret))
+      AWS_ACCESS_KEY_ID: ((aws/mapfs-uploader.role_id))
+      AWS_SECRET_ACCESS_KEY: ((aws/mapfs-uploader.role_secret))
+      AWS_ROLE_ARN: ((aws/mapfs-uploader.role_arn))
       GIT_USERNAME: ((github.user))
       GIT_EMAIL: ((github.email))
       FINAL: true

--- a/nfs-volume-release.yml
+++ b/nfs-volume-release.yml
@@ -126,12 +126,13 @@ resources:
 - name: nfsvolume-version
   type: semver
   source:
-    access_key_id: ((aws/nfsvolume-uploader.id))
+    access_key_id: ((aws/nfsvolume-uploader.role_id))
     bucket: nfsvolume-release-versions
     initial_version: 7.0.2
     key: current-version
     region_name: us-east-1
-    secret_access_key: ((aws/nfsvolume-uploader.secret))
+    secret_access_key: ((aws/nfsvolume-uploader.role_secret))
+    assume_role_arn: ((aws/nfsvolume-uploader.role_arn))
 
 - name: github-release-nfs
   type: github-release
@@ -306,8 +307,9 @@ jobs:
       VENDOR_UPDATES_BRANCH: &golang-vendor-branch bump-golang-vendor-((.:golang-release-version))
       COMMIT_USERNAME: bump-golang CI job
       COMMIT_USEREMAIL: mapbu-cryogenics@groups.vmware.com
-      AWS_ACCESS_KEY_ID: ((aws/nfsvolume-uploader.id))
-      AWS_SECRET_ACCESS_KEY: ((aws/nfsvolume-uploader.secret))
+      AWS_ACCESS_KEY_ID: ((aws/nfsvolume-uploader.role_id))
+      AWS_SECRET_ACCESS_KEY: ((aws/nfsvolume-uploader.role_secret))
+      AWS_ROLE_ARN: ((aws/nfsvolume-uploader.role_arn))
   - put: nfs-volume-release-bump-golang
     params:
       repository: release-with-updated-vendored-package
@@ -586,8 +588,9 @@ jobs:
   - task: bump-openldap
     config:
       params:
-        S3_ACCESS_KEY_ID: ((aws/nfsvolume-uploader.id))
-        S3_ACCESS_KEY: ((aws/nfsvolume-uploader.secret))
+        S3_ACCESS_KEY_ID: ((aws/nfsvolume-uploader.role_id))
+        S3_ACCESS_KEY: ((aws/nfsvolume-uploader.role_secret))
+        S3_ROLE_ARN: ((aws/nfsvolume-uploader.role_arn))
         GIT_AUTHOR_NAME: &git_author_name 'Cryogenics CI Bot'
         GIT_AUTHOR_EMAIL: &git_author_email 'mapbu-cryogenics@groups.vmware.com'
         GIT_COMMITTER_NAME: *git_author_name
@@ -1088,8 +1091,9 @@ jobs:
           updated-release-repo: nfs-final-release
           updated-release-tarball: nfs-final-release-tarball
         params:
-          AWS_ACCESS_KEY_ID: ((aws/nfsvolume-uploader.id))
-          AWS_SECRET_ACCESS_KEY: ((aws/nfsvolume-uploader.secret))
+          AWS_ACCESS_KEY_ID: ((aws/nfsvolume-uploader.role_id))
+          AWS_SECRET_ACCESS_KEY: ((aws/nfsvolume-uploader.role_secret))
+          AWS_ROLE_ARN: ((aws/nfsvolume-uploader.role_arn))
           GIT_USERNAME: ((github.user))
           GIT_EMAIL: ((github.email))
           FINAL: true

--- a/scripts/ci/finalize_release
+++ b/scripts/ci/finalize_release
@@ -21,6 +21,9 @@ blobstore:
     access_key_id: ${S3_ACCESS_KEY_ID}
     secret_access_key: ${S3_ACCESS_KEY}
 EOF
+if [[ ${S3_ROLE_ARN} != "false" ]]; then
+  echo "    assume_role_arn: ${S3_ROLE_ARN}" >> "${RELEASE}/config/private.yml"
+fi
 
 FINAL_RELEASE_VERSION="$(cat "${VERSION}/number")"
 

--- a/scripts/ci/finalize_release.build.yml
+++ b/scripts/ci/finalize_release.build.yml
@@ -21,6 +21,7 @@ params:
   GIT_EMAIL: replace-me
   S3_ACCESS_KEY_ID: replace-me
   S3_ACCESS_KEY: replace-me
+  S3_ROLE_ARN: false
 
 run:
   path: persi-ci/scripts/ci/finalize_release

--- a/shared-units.yml
+++ b/shared-units.yml
@@ -45,22 +45,24 @@ resources:
 - name: goshims-version
   type: semver
   source:
-    access_key_id: ((aws/goshims-uploader.id))
+    access_key_id: ((aws/goshims-uploader.role_id))
     bucket: goshims-versions
     initial_version: 0.1.0
     key: current-version
     region_name: us-east-1
-    secret_access_key: ((aws/goshims-uploader.secret))
+    secret_access_key: ((aws/goshims-uploader.role_secret))
+    assume_role_arn: ((aws/goshims-uploader.role_arn))
 
 - name: existingvolumebroker-version
   type: semver
   source:
-    access_key_id: ((aws/existingvolumebroker-uploader.id))
+    access_key_id: ((aws/existingvolumebroker-uploader.role_id))
     bucket: existingvolumebroker-versions
     initial_version: 0.1.0
     key: current-version
     region_name: us-east-1
-    secret_access_key: ((aws/existingvolumebroker-uploader.secret))
+    secret_access_key: ((aws/existingvolumebroker-uploader.role_secret))
+    assume_role_arn: ((aws/existingvolumebroker-uploader.role_arn))
 
 - name: service-broker-store
   type: git
@@ -72,12 +74,13 @@ resources:
 - name: service-broker-store-version
   type: semver
   source:
-    access_key_id: ((aws/service-broker-store-uploader.id))
+    access_key_id: ((aws/service-broker-store-uploader.role_id))
     bucket: service-broker-store-versions
     initial_version: 0.1.0
     key: current-version
     region_name: us-east-1
-    secret_access_key: ((aws/service-broker-store-uploader.secret))
+    secret_access_key: ((aws/service-broker-store-uploader.role_secret))
+    assume_role_arn: ((aws/service-broker-store-uploader.role_arn))
 
 - name: volumedriver
   type: git
@@ -89,12 +92,13 @@ resources:
 - name: volumedriver-version
   type: semver
   source:
-    access_key_id: ((aws/volumedriver-uploader.id))
+    access_key_id: ((aws/volumedriver-uploader.role_id))
     bucket: volumedriver-versions
     initial_version: 0.1.0
     key: current-version
     region_name: us-east-1
-    secret_access_key: ((aws/volumedriver-uploader.secret))
+    secret_access_key: ((aws/volumedriver-uploader.role_secret))
+    assume_role_arn: ((aws/volumedriver-uploader.role_arn))
 
 - name: volume-mount-options
   type: git
@@ -106,12 +110,13 @@ resources:
 - name: volume-mount-options-version
   type: semver
   source:
-    access_key_id: ((aws/volume-mount-options-uploader.id))
+    access_key_id: ((aws/volume-mount-options-uploader.role_id))
     bucket: volume-mount-options-versions
     initial_version: 0.1.0
     key: current-version
     region_name: us-east-1
-    secret_access_key: ((aws/volume-mount-options-uploader.secret))
+    secret_access_key: ((aws/volume-mount-options-uploader.role_secret))
+    assume_role_arn: ((aws/volume-mount-options-uploader.role_arn))
 
 - name: volumedriver-pr
   type: pull-request

--- a/smb-volume-release.yml
+++ b/smb-volume-release.yml
@@ -89,12 +89,13 @@ resources:
 - name: smb-volume-version
   type: semver
   source:
-    access_key_id: ((aws/smbvolume-uploader.id))
+    access_key_id: ((aws/smbvolume-uploader.role_id))
     bucket: smb-volume-release-versions
     initial_version: 3.0.2
     key: current-version
     region_name: us-east-1
-    secret_access_key: ((aws/smbvolume-uploader.secret))
+    secret_access_key: ((aws/smbvolume-uploader.role_secret))
+    assume_role_arn: ((aws/smbvolume-uploader.role_arn))
 
 - name: github-release-smb
   type: github-release
@@ -237,8 +238,9 @@ jobs:
       VENDOR_UPDATES_BRANCH: &golang-vendor-branch bump-golang-vendor-((.:golang-release-version))
       COMMIT_USERNAME: bump-golang CI job
       COMMIT_USEREMAIL: mapbu-cryogenics@groups.vmware.com
-      AWS_ACCESS_KEY_ID: ((aws/smbvolume-uploader.id))
-      AWS_SECRET_ACCESS_KEY: ((aws/smbvolume-uploader.secret))
+      AWS_ACCESS_KEY_ID: ((aws/smbvolume-uploader.role_id))
+      AWS_SECRET_ACCESS_KEY: ((aws/smbvolume-uploader.role_secret))
+      AWS_ROLE_ARN: ((aws/nfsvolume-uploader.role_arn))
   - put: smb-volume-release-bump-golang
     params:
       repository: release-with-updated-vendored-package
@@ -638,8 +640,9 @@ jobs:
       updated-release-repo: smb-final-release
       updated-release-tarball: smb-final-release-tarball
     params:
-      AWS_ACCESS_KEY_ID: ((aws/smbvolume-uploader.id))
-      AWS_SECRET_ACCESS_KEY: ((aws/smbvolume-uploader.secret))
+      AWS_ACCESS_KEY_ID: ((aws/smbvolume-uploader.role_id))
+      AWS_SECRET_ACCESS_KEY: ((aws/smbvolume-uploader.role_secret))
+      AWS_ROLE_ARN: ((aws/smbvolume-uploader.role_arn))
       GIT_USERNAME: ((github.user))
       GIT_EMAIL: ((github.email))
       FINAL: true


### PR DESCRIPTION
[#184997269]

update persi ci to use switch role creds across pipelines.

old credentials have been kept in place in vault and new values were added.