### PR TITLE
all bumpers should be serial

### DIFF
--- a/lts-nfs-volume-release-v5.0.yml
+++ b/lts-nfs-volume-release-v5.0.yml
@@ -459,6 +459,7 @@ resources:
 
 jobs:
 - name: bump-libevent
+  serial: true
   plan:
   - in_parallel:
     - get: libevent-release
@@ -502,6 +503,7 @@ jobs:
         LABELS: dependencies,v5
 
 - name: bump-rpcsvc-proto
+  serial: true
   plan:
   - in_parallel:
     - get: rpcsvc-proto-release
@@ -545,6 +547,7 @@ jobs:
         LABELS: dependencies,v5
 
 - name: bump-libtirpc
+  serial: true
   plan:
   - in_parallel:
     - get: libtirpc-version
@@ -606,6 +609,7 @@ jobs:
         LABELS: dependencies,v5
 
 - name: bump-rpcbind
+  serial: true
   plan:
   - in_parallel:
     - get: rpcbind-version
@@ -667,6 +671,7 @@ jobs:
         LABELS: dependencies,v5
 
 - name: bump-tcl
+  serial: true
   plan:
   - in_parallel:
     - get: tcl-version
@@ -728,6 +733,7 @@ jobs:
         LABELS: dependencies,v5
 
 - name: bump-util-linux
+  serial: true
   plan:
   - in_parallel:
     - get: util-linux
@@ -772,6 +778,7 @@ jobs:
         TITLE: "Bump util-linux to v((.:util-linux-version))"
         LABELS: dependencies,v5
 - name: bump-sqlite
+  serial: true
   plan:
   - in_parallel:
     - get: sqlite-release
@@ -832,6 +839,7 @@ jobs:
         TITLE: "Bump SQLite to v((.:sqlite-version))"
         LABELS: dependencies,v5
 - name: bump-nfs-utils
+  serial: true
   plan:
   - in_parallel:
     - get: nfs-utils-version
@@ -893,6 +901,7 @@ jobs:
         TITLE: "Bump NFS-Utils to v((.:nfs-utils.version.ref))"
         LABELS: dependencies,v5
 - name: bump-openldap
+  serial: true
   plan:
   - in_parallel:
     - get: openldap-version
@@ -955,6 +964,7 @@ jobs:
         LABELS: dependencies,v5
 
 - name: bump-openssl
+  serial: true
   plan:
   - in_parallel:
     - get: openssl
@@ -999,6 +1009,7 @@ jobs:
         TITLE: "Bump OpenSSL to v((.:new-version))"
         LABELS: dependencies,v5
 - name: bump-golang
+  serial: true
   plan:
   - in_parallel:
     - get: image-cryo-essentials
@@ -1056,6 +1067,7 @@ jobs:
         source-repo: nfs-volume-release-lts-write
 
 - name: update-go-directive-for-nfsv3driver
+  serial: true
   plan:
   - in_parallel:
     - get: image-cryo-essentials
@@ -1101,6 +1113,7 @@ jobs:
         source-repo: nfsv3driver-v5-write
 
 - name: update-go-directive-for-nfsbroker
+  serial: true
   plan:
   - in_parallel:
     - get: image-cryo-essentials

--- a/lts-nfsbroker-v5.0.yml
+++ b/lts-nfsbroker-v5.0.yml
@@ -158,6 +158,7 @@ jobs:
       repository: nfsbroker
 
 - name: bump-go-module
+  serial: true
   plan:
   - in_parallel:
     - get: run-once-a-day

--- a/mapfs-release.yml
+++ b/mapfs-release.yml
@@ -374,6 +374,7 @@ jobs:
       RELEASE_VERSION: pre-release-cve-scan
 
 - name: bump-libfuse
+  serial: true
   plan:
   - in_parallel:
     - get: cryogenics-concourse-tasks
@@ -419,6 +420,7 @@ jobs:
         LABELS: dependencies
 
 - name: bump-golang
+  serial: true
   plan:
   - in_parallel:
     - get: cryogenics-concourse-tasks
@@ -475,6 +477,7 @@ jobs:
         source-repo: mapfs-release-write
 
 - name: update-go-directive-for-mapfs
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release
@@ -525,6 +528,7 @@ jobs:
       source-repo: mapfs-write
 
 - name: update-go-directive-for-mapfs-release
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release

--- a/nfs-volume-release.yml
+++ b/nfs-volume-release.yml
@@ -564,6 +564,7 @@ jobs:
       RELEASE_VERSION: pre-release-cve-scan
 
 - name: bump-nfs-utils
+  serial: true
   plan:
   - in_parallel:
     - get: nfs-utils-version
@@ -626,6 +627,7 @@ jobs:
         LABELS: dependencies
 
 - name: bump-sqlite
+  serial: true
   plan:
   - in_parallel:
     - get: sqlite-release
@@ -687,6 +689,7 @@ jobs:
         LABELS: dependencies
 
 - name: bump-libevent
+  serial: true
   plan:
   - in_parallel:
     - get: libevent-release
@@ -730,6 +733,7 @@ jobs:
         LABELS: dependencies
 
 - name: bump-rpcsvc-proto
+  serial: true
   plan:
   - in_parallel:
     - get: rpcsvc-proto-release
@@ -773,6 +777,7 @@ jobs:
         LABELS: dependencies
 
 - name: bump-libtirpc
+  serial: true
   plan:
   - in_parallel:
     - get: libtirpc-version
@@ -834,6 +839,7 @@ jobs:
         LABELS: dependencies
 
 - name: bump-rpcbind
+  serial: true
   plan:
   - in_parallel:
     - get: rpcbind-version
@@ -895,6 +901,7 @@ jobs:
         LABELS: dependencies
 
 - name: bump-tcl
+  serial: true
   plan:
   - in_parallel:
     - get: tcl-version
@@ -956,6 +963,7 @@ jobs:
         LABELS: dependencies
 
 - name: bump-util-linux
+  serial: true
   plan:
   - in_parallel:
     - get: util-linux
@@ -1001,6 +1009,7 @@ jobs:
         LABELS: dependencies
 
 - name: bump-golang
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release
@@ -1056,6 +1065,7 @@ jobs:
         source-repo: nfs-volume-release-write
 
 - name: update-go-directive-for-nfsv3driver
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release
@@ -1102,6 +1112,7 @@ jobs:
         source-repo: nfsv3driver-write
 
 - name: update-go-directive-for-nfsbroker
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release
@@ -1137,6 +1148,7 @@ jobs:
       source-repo: nfsbroker-write
 
 - name: update-go-directive-for-volumedriver
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release
@@ -1183,6 +1195,7 @@ jobs:
         source-repo: volumedriver-write
 
 - name: update-go-directive-for-volume-mount-options
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release
@@ -1229,6 +1242,7 @@ jobs:
         source-repo: volume-mount-options-write
 
 - name: update-go-directive-for-existingvolumebroker
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release
@@ -1275,6 +1289,7 @@ jobs:
         source-repo: existingvolumebroker-write
 
 - name: update-go-directive-for-service-broker-store
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release
@@ -1321,6 +1336,7 @@ jobs:
         source-repo: service-broker-store-write
 
 - name: bump-openssl
+  serial: true
   plan:
   - in_parallel:
     - get: openssl
@@ -1366,6 +1382,7 @@ jobs:
         LABELS: dependencies
 
 - name: bump-openldap
+  serial: true
   plan:
   - in_parallel:
     - get: openldap-version

--- a/nfsbroker.yml
+++ b/nfsbroker.yml
@@ -167,6 +167,7 @@ jobs:
       repository: nfsbroker
 
 - name: bump-go-module
+  serial: true
   plan:
   - in_parallel:
     - get: run-once-a-day

--- a/smb-volume-release.yml
+++ b/smb-volume-release.yml
@@ -443,6 +443,7 @@ jobs:
       RELEASE_VERSION: pre-release-cve-scan
 
 - name: *bump-blob-cifs-utils-job-name
+  serial: true
   plan:
   - in_parallel:
     - get: cifs-utils-latest
@@ -503,6 +504,7 @@ jobs:
       input_mapping:
         source-repo: smb-volume-release-master-write
 - name: *bump-blob-keyutils-job-name
+  serial: true
   plan:
   - in_parallel:
     - get: keyutils-latest
@@ -564,6 +566,7 @@ jobs:
         source-repo: smb-volume-release-master-write
 
 - name: *bump-blob-autoconf-job-name
+  serial: true
   plan:
   - in_parallel:
     - get: autoconf-latest
@@ -610,6 +613,7 @@ jobs:
         source-repo: smb-volume-release-master-write
 
 - name: *bump-blob-automake-job-name
+  serial: true
   plan:
   - in_parallel:
     - get: automake-latest
@@ -655,6 +659,7 @@ jobs:
         source-repo: smb-volume-release-master-write
 
 - name: *bump-blob-talloc-job-name
+  serial: true
   plan:
   - in_parallel:
     - get: talloc-latest
@@ -716,6 +721,7 @@ jobs:
         source-repo: smb-volume-release-master-write
 
 - name: *bump-blob-libtool-job-name
+  serial: true
   plan:
   - in_parallel:
     - get: libtool-latest
@@ -761,6 +767,7 @@ jobs:
         source-repo: smb-volume-release-master-write
 
 - name: bump-golang
+  serial: true
   plan:
   - in_parallel:
     - get: cryogenics-concourse-tasks
@@ -816,6 +823,7 @@ jobs:
         source-repo: smb-volume-release-master-write
 
 - name: update-go-directive-for-smbbroker-for-gomod-directive-updates
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release
@@ -866,6 +874,7 @@ jobs:
       source-repo: smbbroker-write
 
 - name: update-go-directive-for-smbdriver-for-gomod-directive-updates
+  serial: true
   plan:
   - in_parallel:
     - get: golang-release


### PR DESCRIPTION
[#187071309]
they currently force push. That created issues when the same job got triggered twice ( for unknown reasons ) and job n-1 "overtook" job n ( n used a newer HEAD ) and force pushed over the changes made by n.